### PR TITLE
Fix PHP 5.3 syntax issues

### DIFF
--- a/src/Jaspersoft/Dto/Resource/CompositeResource.php
+++ b/src/Jaspersoft/Dto/Resource/CompositeResource.php
@@ -52,7 +52,8 @@ abstract class CompositeResource extends Resource
                     if (CompositeDTOMapper::isReferenceKey($k)) {
                         $items[$k] = $this->resolveSubresource($k, $v, $class);
                     } else if (CompositeDTOMapper::isCollectionField($field, $class)) {
-                        $fileField = CompositeDTOMapper::collectionKeyValuePair($class, $field)[1];
+                        $collectionKeyValuePair = CompositeDTOMapper::collectionKeyValuePair($class, $field);
+                        $fileField = $collectionKeyValuePair[1];
                         $items[$k] = $this->resolveSubresource($fileField, $v, $class);
                     } else {
                         $items[$k] = $v;


### PR DESCRIPTION
The library uses PHP 5.4+ features like function array dereferencing which breaks PHP 5.3 compatibility as stated in composer.json.
