### PR TITLE
Fix for: Import failed. Reason: Organization with id true does not ex…

### DIFF
--- a/src/Jaspersoft/Dto/ImportExport/ImportTask.php
+++ b/src/Jaspersoft/Dto/ImportExport/ImportTask.php
@@ -39,7 +39,7 @@ class ImportTask extends DTOObject
     {
         $data = array();
         foreach (get_object_vars($this) as $k => $v) {
-            if (!empty($v) && $v == true) {
+            if (!empty($v) && $v === true) {
                 $data[$k] = 'true';
             } elseif (!empty($v)) {
                 $data[$k] = $v;


### PR DESCRIPTION
When creating import task class ImportTask.php convert strings to booleans (if organization is set to organization='test-org' it converts it to organization=true), and it breaks the import.
