### PR TITLE
Added ignorePagination parameter

### DIFF
--- a/src/Jaspersoft/Service/ReportService.php
+++ b/src/Jaspersoft/Service/ReportService.php
@@ -27,16 +27,18 @@ class ReportService extends JRSService
      * @param boolean $freshData
      * @param boolean $saveDataSnapshot
      * @param string $transformerKey For use when running a report as a JasperPrint. Specifies print element transformers
+     * @param boolean $ignorePagination Should report be printed continuously, ignoring pages breaks?
      * @return string Binary data of report
      */
 	public function runReport($uri, $format = 'pdf', $pages = null, $attachmentsPrefix = null, $inputControls = null,
-                                $interactive = true, $onePagePerSheet = false, $freshData = true, $saveDataSnapshot = false, $transformerKey = null)
+                                $interactive = true, $onePagePerSheet = false, $freshData = true, $saveDataSnapshot = false, 
+				$transformerKey = null, $ignorePagination = false)
     {
 		$url = $this->service_url . '/reports' . $uri . '.' . $format;
         if (empty($inputControls))
-            $url .= '?' . Util::query_suffix(compact("pages", "attachmentsPrefix", "interactive", "onePagePerSheet", "freshData", "saveDataSnapshot", "transformerKey"));
+            $url .= '?' . Util::query_suffix(compact("pages", "attachmentsPrefix", "interactive", "onePagePerSheet", "freshData", "saveDataSnapshot", "transformerKey", "ignorePagination"));
         else
-            $url .= '?' . Util::query_suffix(array_merge(compact("pages", "attachmentsPrefix", "interactive", "onePagePerSheet", "freshData", "saveDataSnapshot", "transformerKey"), $inputControls));
+            $url .= '?' . Util::query_suffix(array_merge(compact("pages", "attachmentsPrefix", "interactive", "onePagePerSheet", "freshData", "saveDataSnapshot", "transformerKey", "ignorePagination"), $inputControls));
 		$binary = $this->service->prepAndSend($url, array(200), 'GET', null, true);
 		return $binary;
 	}


### PR DESCRIPTION
Added ignorePagination as parameter of runReport.

Described in https://community.jaspersoft.com/wiki/non-paginated-export-rest-v2 we can add ignorePagination parameter to URL so the report can be printed continuously without the page breaks.

Added as last parameter, so it can keep the backwards compatibility.