### PR TITLE
bugfix: problem in import service with missing "Continue" keyword in the HTTP/1.1 100 header

### DIFF
--- a/src/Jaspersoft/Tool/RESTRequest.php
+++ b/src/Jaspersoft/Tool/RESTRequest.php
@@ -260,7 +260,7 @@ class RESTRequest
         $response = curl_exec($curlHandle);
         $this->response_info = curl_getinfo($curlHandle);
 
-        $response = preg_replace("/^(?:HTTP\/1.1 100 Continue.*?\\r\\n\\r\\n)+/ms", "", $response);
+        $response = preg_replace("/^(?:HTTP\/1.1 100.*?\\r\\n\\r\\n)+/ms", "", $response);
 
         //  100-continue chunks are returned on multipart communications
         $headerblock = strstr($response, "\r\n\r\n", true);


### PR DESCRIPTION
when the server doesn't send the "Continue" keyword in the "HTTP/1.1 100" header, this header will not be stripped correctly.

Then also the rest of the header will not be stripped correctly, but ends up in the response_body, which causes an expection
when trying to convert the JSON data of the response_body.